### PR TITLE
resolve #3: change default firebase hosting emulator port from 5000

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -26,6 +26,9 @@
     },
     "ui": {
       "enabled": true
+    },
+    "hosting": {
+      "port": 5002
     }
   },
   "hosting": {

--- a/firebase.json
+++ b/firebase.json
@@ -22,7 +22,7 @@
       "port": 5001
     },
     "firestore": {
-      "port": 8080
+      "port": 8081
     },
     "ui": {
       "enabled": true

--- a/src/config/firebase-config.ts
+++ b/src/config/firebase-config.ts
@@ -42,5 +42,5 @@ export const firestore = getFirestore(app);
 
 if (process.env.NODE_ENV === "development") {
   connectAuthEmulator(auth, "http://localhost:9099");
-  connectFirestoreEmulator(firestore, "localhost", 8080);
+  connectFirestoreEmulator(firestore, "localhost", 8081);
 }


### PR DESCRIPTION
### Description

See #3 

Also updates the emulator port for Firestone to 8081 since 8080 is commonly used.

### How To Test

1. Ensure the hosting emulator starts and works without error on macOS Monterey