### PR TITLE
fix #4: prevent task edit dialog from opening when selecting text in row

### DIFF
--- a/src/queue/components/QueueTableRowsGrouped.tsx
+++ b/src/queue/components/QueueTableRowsGrouped.tsx
@@ -50,6 +50,10 @@ export function QueueTableRowsGrouped({
   const [showQueueItemEditDialog, setShowQueueItemEditDialog] = useState(false);
   const [selectedQueueItem, setSelectedQueueItem] = useState<QueueItem | undefined>(undefined);
   const handleQueueItemEditDialogOpen = (task: QueueItem) => {
+    // prevent dialog open when selecting row text
+    const selection = window.getSelection();
+    if (selection && selection.toString().length) return
+
     setSelectedQueueItem(task);
     setShowQueueItemEditDialog(true);
   };


### PR DESCRIPTION
### Description

See #4 

### How To Test

1. Ensure that task edit dialog doesn't open when you highlight text in a task row